### PR TITLE
Clean output for some commands

### DIFF
--- a/mtx/loaderinfo.cpp
+++ b/mtx/loaderinfo.cpp
@@ -485,13 +485,8 @@ int main(int argc, char **argv)
 	char *filename;
 
 	argv0=argv[0];
-	if (argc != 3)
-	{
-		fprintf(stderr,"argc=%d",argc);
-		usage();
-	}
 
-	if (strcmp(argv[1],"-f")!=0)
+	if (argc != 3 || strcmp(argv[1],"-f")!=0)
 	{
 		usage();
 	}

--- a/mtx/mtx.cpp
+++ b/mtx/mtx.cpp
@@ -226,7 +226,14 @@ static void do_Position(void)
 	}
 
 	src = ElementStatus->StorageElementAddress[driveno];
+
+	fprintf(stdout, "Moving Element to position %d...", arg1);
+	fflush(stdout);
+
 	Position(src);
+
+	fprintf(stdout,"done\n");
+	fflush(stdout);
 }
 
 
@@ -480,44 +487,50 @@ static void ReportInquiry(void)
 	free(Inquiry);		/* well, we're about to exit, but ... */
 }
 
+static void print_VolumeTag(unsigned char *taglabel)
+{
+	for(int i=0;i<BARCODE_LENGTH;++i)if(taglabel[i]!=' ')printf("%c",taglabel[i]);
+}
+
 static void Status(void)
 {
 	int StorageElementNumber;
 	int TransferElementNumber;
 
-	printf( "  Storage Changer %s:%d Drives, %d Slots ( %d Import/Export )\n",
+	printf( "  Storage Changer %s: %d Drives, %d Slots ( %d Import/Export )\n",
 			device,
 			ElementStatus->DataTransferElementCount,
 			ElementStatus->StorageElementCount,
 			ElementStatus->ImportExportCount);
 
-
 	for (TransferElementNumber = 0; 
-		 TransferElementNumber < ElementStatus->DataTransferElementCount;
-		 TransferElementNumber++)
+		TransferElementNumber < ElementStatus->DataTransferElementCount;
+		TransferElementNumber++)
 	{
 		
-		printf("Data Transfer Element %d:", TransferElementNumber);
+		printf("Data Transfer Element %02d: ", TransferElementNumber);
 		if (ElementStatus->DataTransferElementFull[TransferElementNumber])
 		{
-			if (ElementStatus->DataTransferElementSourceStorageElementNumber[TransferElementNumber] > -1)
-			{
-				printf("Full (Storage Element %d Loaded)",
-						ElementStatus->DataTransferElementSourceStorageElementNumber[TransferElementNumber]+1);
-			}
-			else
-			{
-				printf("Full (Unknown Storage Element Loaded)");
-			}
-
 			if (ElementStatus->DataTransferPrimaryVolumeTag[TransferElementNumber][0])
 			{
-				printf(":VolumeTag = %s", ElementStatus->DataTransferPrimaryVolumeTag[TransferElementNumber]);
+				printf(" Full: VolumeTag=");
+				print_VolumeTag(ElementStatus->DataTransferPrimaryVolumeTag[TransferElementNumber]);
 			}
 
 			if (ElementStatus->DataTransferAlternateVolumeTag[TransferElementNumber][0])
 			{
-				printf(":AlternateVolumeTag = %s", ElementStatus->DataTransferAlternateVolumeTag[TransferElementNumber]); 
+				printf(" Full: VolumeTag=");
+				print_VolumeTag(ElementStatus->DataTransferAlternateVolumeTag[TransferElementNumber]);
+			}
+
+			if (ElementStatus->DataTransferElementSourceStorageElementNumber[TransferElementNumber] > -1)
+			{
+				printf(": (Storage Element %d Loaded)",
+					ElementStatus->DataTransferElementSourceStorageElementNumber[TransferElementNumber]+1);
+			}
+			else
+			{
+				printf(": (Unknown Storage Element Loaded)");
 			}
 			putchar('\n');
 		}
@@ -531,19 +544,23 @@ static void Status(void)
 		 StorageElementNumber < ElementStatus->StorageElementCount;
 		 StorageElementNumber++)
 	{
-		printf(	"      Storage Element %d%s:%s", StorageElementNumber + 1,
-				(ElementStatus->StorageElementIsImportExport[StorageElementNumber]) ? " IMPORT/EXPORT" : "",
-				(ElementStatus->StorageElementFull[StorageElementNumber] ? "Full " : "Empty"));
+		printf(	"      Storage Element %02d: %5s", StorageElementNumber + 1,
+				(ElementStatus->StorageElementFull[StorageElementNumber] ? "Full" : "Empty"));
 
 		if (ElementStatus->PrimaryVolumeTag[StorageElementNumber][0])
 		{
-			printf(":VolumeTag=%s", ElementStatus->PrimaryVolumeTag[StorageElementNumber]);
+			printf(": VolumeTag=");
+			print_VolumeTag(ElementStatus->PrimaryVolumeTag[StorageElementNumber]);
 		}
 
 		if (ElementStatus->AlternateVolumeTag[StorageElementNumber][0])
 		{
-			printf(":AlternateVolumeTag=%s", ElementStatus->AlternateVolumeTag[StorageElementNumber]);
+			printf(": AlternateVolumeTag=");
+			print_VolumeTag(ElementStatus->AlternateVolumeTag[StorageElementNumber]);
 		}
+
+		printf("%s", (ElementStatus->StorageElementIsImportExport[StorageElementNumber]) ? ": IMPORT/EXPORT" : "");
+
 		putchar('\n');
 	}
 
@@ -683,7 +700,14 @@ static void Transfer(void)
 
 	src = ElementStatus->StorageElementAddress[arg1 - 1];
 	dest = ElementStatus->StorageElementAddress[arg2 - 1];
-	Move(src,dest);
+
+	fprintf(stdout, "Transfering media from Storage Element %d to %d...", arg1, arg2);
+	fflush(stdout);
+
+	Move(src,dest);  /* load it into the particular slot, if possible! */
+
+	fprintf(stdout,"done\n");
+	fflush(stdout);
 }
 
 /****************************************************************

--- a/mtx/mtx.h
+++ b/mtx/mtx.h
@@ -535,8 +535,8 @@ TransportElementDescriptor_T;
 
 
 /* Now for element status data; */
-
-typedef unsigned char barcode[37];
+#define BARCODE_LENGTH 37
+typedef unsigned char barcode[BARCODE_LENGTH];
 
 typedef struct ElementStatus {
 

--- a/mtx/tapeinfo.cpp
+++ b/mtx/tapeinfo.cpp
@@ -930,16 +930,11 @@ int main(int argc, char **argv)
 
 	argv0=argv[0];
 
-	if (argc != 3)
+	if (argc != 3 || strcmp(argv[1],"-f")!=0)
 	{
-		fprintf(stderr,"argc=%d",argc);
 		usage();
 	}
 
-	if (strcmp(argv[1],"-f")!=0)
-	{
-		usage();
-	}
 	filename=argv[2];
 
 	fd=SCSI_OpenDevice(filename);


### PR DESCRIPTION
loaderinfo.cpp: remove print arg and combine arg check to single if

mtx.cpp:        add output for "position" and "transfer" commands, standardize
                output format for "status" commnad, and create new
                funtion to print volume tags

mtx.h:          change barcode length to be defined for use in
                mtx.cpp:print_VolumeTag

tapeinfo.cpp:   remove print arg and combine arg check to single if